### PR TITLE
geoserver-lb - make GS' livenessProbe configureable

### DIFF
--- a/geoserver-lb/Chart.yaml
+++ b/geoserver-lb/Chart.yaml
@@ -2,5 +2,5 @@ name: geoserver-lb
 apiVersion: v2
 description: A Helm chart for deploying geoserver loadbalanced
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: "22.0.4"

--- a/geoserver-lb/templates/geoserver-deploy.yaml
+++ b/geoserver-lb/templates/geoserver-deploy.yaml
@@ -204,14 +204,7 @@ spec:
         image: {{ .Values.geoserver.docker_image }}
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities
-            port: 8080
-            scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
+        {{- .Values.geoserver.livenessProbe | toYaml | nindent 10 }}
         ports:
         - containerPort: 8080
           name: http-proxy

--- a/geoserver-lb/values.yaml
+++ b/geoserver-lb/values.yaml
@@ -3,6 +3,15 @@ geoserver:
   # This is the url to the service provided by the geOrchestra helm chart
   master_svc_url: georchestra-geoserver-svc:8080
   docker_image: registry.com/org/client-configuration/geoserver:22.0.4
+  livenessProbe:
+    httpGet:
+      path: /geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities
+      port: 8080
+      scheme: HTTP
+    periodSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1
+    timeoutSeconds: 5
   # pull_secret: ghcr-registry-secret
   replicas: 1
   jetty_monitoring: false


### PR DESCRIPTION
By default, the liveness probe for the geoserver slave deployments is configured to hit a WMTS GetCapabilities. On platform containing a lot of data, this can lead to produce huge XML documents (e.g. 5.5MB on DataGrandEst), which is not relevant for a healthcheck. Also producing the document can take time which won't fit in the 5 seconds default timeout.

This PR aims to make it configurable so that we can use more convenient endpoints to test liveness, and raise the 5s timeout limit.

