### PR TITLE
acceptance - add a podmonitor

### DIFF
--- a/acceptance-tests/templates/prometheus-pm.yaml
+++ b/acceptance-tests/templates/prometheus-pm.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "acceptance-tests.fullname" . }}-pm
 spec:
   podMetricsEndpoints:
-  - interval: 1d
+  - interval: {{ .Values.podMonitor.frequency }}
     path: {{ .Values.podMonitor.httpPath }}
     port: {{ .Values.podMonitor.httpPort }}
   selector:

--- a/acceptance-tests/templates/prometheus-pm.yaml
+++ b/acceptance-tests/templates/prometheus-pm.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    {{- include "acceptance-tests.labels" . | nindent 4 }}
+  name: {{ include "acceptance-tests.fullname" . }}-pm
+spec:
+  podMetricsEndpoints:
+  - interval: 1d
+    path: {{ .Values.podMonitor.httpPath }}
+    port: {{ .Values.podMonitor.httpPort }}
+  selector:
+    matchLabels:
+      {{- with .Values.podMonitor.matchLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/acceptance-tests/values.yaml
+++ b/acceptance-tests/values.yaml
@@ -64,6 +64,7 @@ configuration:
 # file which can be scrapped.
 podMonitor:
   enabled: false
+  # match the pod where prometheusData.txt is hosted
   matchLabels:
     app.camptocamp.com/name: apache-nas
   httpPath: /public/non-regression/report/export/prometheusData.txt

--- a/acceptance-tests/values.yaml
+++ b/acceptance-tests/values.yaml
@@ -58,3 +58,13 @@ configuration:
     localAccount:
       username: myusername
       password: mypassword
+
+# If enabled, this will create a PodMonitor object in order
+# to gather metrics on the tests, as allure provides a prometheus compatible
+# file which can be scrapped.
+podMonitor:
+  enabled: false
+  matchLabels:
+    app.camptocamp.com/name: apache-nas
+  httpPath: /public/non-regression/report/export/prometheusData.txt
+  httpPort: "80"

--- a/acceptance-tests/values.yaml
+++ b/acceptance-tests/values.yaml
@@ -66,6 +66,6 @@ podMonitor:
   enabled: false
   # match the pod where prometheusData.txt is hosted
   matchLabels:
-    app.camptocamp.com/name: apache-nas
+    app.kubernetes.io/name: apache-nas
   httpPath: /public/non-regression/report/export/prometheusData.txt
   httpPort: "80"

--- a/acceptance-tests/values.yaml
+++ b/acceptance-tests/values.yaml
@@ -69,3 +69,5 @@ podMonitor:
     app.kubernetes.io/name: apache-nas
   httpPath: /public/non-regression/report/export/prometheusData.txt
   httpPort: "80"
+  # Should be set to a value coherent with the `job.schedule` parameter above.
+  frequency: 1d


### PR DESCRIPTION
This allows publishing metrics to prometheus about the acceptance tests. 