### PR TITLE
fix: gs-datadir-sync - better naming for the deployment object (fixes #34)

### DIFF
--- a/geoserver-datadir-sync/Chart.yaml
+++ b/geoserver-datadir-sync/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/geoserver-datadir-sync/templates/deployment.yaml
+++ b/geoserver-datadir-sync/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "geoserver-datadir-sync.fullname" . }}-sync-ssh-key
+  name: {{ include "geoserver-datadir-sync.fullname" . }}-depl
   labels:
     {{- include "geoserver-datadir-sync.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
See #34 for the context