### PR TITLE
feat: geocontrib - add possibility to customize *Probes on geocontrib-depl deployment

### DIFF
--- a/geocontrib/templates/geocontrib-depl.yaml
+++ b/geocontrib/templates/geocontrib-depl.yaml
@@ -19,6 +19,9 @@ spec:
           image: {{ .Values.geocontrib.image }}
           imagePullPolicy: {{ .Values.geocontrib.pullPolicy }}
           livenessProbe:
+          {{- if .Values.geocontrib.livenessProbe }}
+          {{- .Values.geocontrib.livenessProbe | toYaml | nindent 11 }}
+          {{- else }}
             failureThreshold: 3
             periodSeconds: 10
             successThreshold: 1
@@ -26,7 +29,11 @@ spec:
             initialDelaySeconds: 210
             tcpSocket:
               port: 5000
+          {{- end }}
           readinessProbe:
+          {{- if .Values.geocontrib.readinessProbe }}
+          {{- .Values.geocontrib.readinessProbe | toYaml | nindent 11 }}
+          {{- else }}
             failureThreshold: 3
             periodSeconds: 10
             initialDelaySeconds: 210
@@ -34,6 +41,7 @@ spec:
             timeoutSeconds: 1
             tcpSocket:
               port: 5000
+          {{- end }}
           {{- with .Values.env_variables }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/geocontrib/values.yaml
+++ b/geocontrib/values.yaml
@@ -2,6 +2,8 @@ geocontrib:
   image: neogeo/geocontrib:5.0.2
   pullPolicy: IfNotPresent
   resources: {}
+  livenessProbe: {}
+  readinessProbe: {}
 
 frontend:
   image: neogeo/geocontrib-front:5.0.2


### PR DESCRIPTION
Some geocontrib deployments require more time than what the chart currently sets by default to bootstrap themselves. Giving the possibility to override the default probes advised via a variable from the values.yaml.

tests: mainly `helm template .` to check if indentation was correct.