### PR TITLE
chore: [GSEST-576] Switch readiness to startupprobe for geocontrib

### DIFF
--- a/geocontrib/templates/geocontrib-depl.yaml
+++ b/geocontrib/templates/geocontrib-depl.yaml
@@ -26,10 +26,10 @@ spec:
             initialDelaySeconds: 210
             tcpSocket:
               port: 5000
-          readinessProbe:
-            failureThreshold: 3
-            periodSeconds: 10
-            initialDelaySeconds: 210
+          startupProbe:
+            # try for 7 minutes until give up
+            failureThreshold: 14
+            periodSeconds: 30
             successThreshold: 1
             timeoutSeconds: 1
             tcpSocket:


### PR DESCRIPTION
Linked to ticket https://camptocamp.atlassian.net/browse/GSEST-576

Switch from a readiness to startupprobe in order to cover all the geocontrib client use cases.

This will wait for 7 minutes for geocontrib to startup and check every 30 seconds.

Will work on geocontrib that start in 2 minutes up to geocontrib that start in 7 minutes.