### PR TITLE
chore: don't create the collectd config if jetty_monitoring disabled

### DIFF
--- a/geoserver-lb/Chart.yaml
+++ b/geoserver-lb/Chart.yaml
@@ -2,5 +2,5 @@ name: geoserver-lb
 apiVersion: v2
 description: A Helm chart for deploying geoserver loadbalanced
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: "22.0.4"

--- a/geoserver-lb/templates/geoserver-monitoring-cm.yaml
+++ b/geoserver-lb/templates/geoserver-monitoring-cm.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.geoserver.jetty_monitoring }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -163,3 +164,4 @@ data:
          </Connection>
        </Plugin>
     </Plugin>
+{{- end }}


### PR DESCRIPTION
if the flag `jetty_monitoring` is set to `false`, we don't need to create a configMap with the collectd configuration.

tests: `helm template .` looks ok