### PR TITLE
chore: being able to override the git image - geoserver-lb

### DIFF
--- a/geoserver-lb/Chart.yaml
+++ b/geoserver-lb/Chart.yaml
@@ -2,5 +2,5 @@ name: geoserver-lb
 apiVersion: v2
 description: A Helm chart for deploying geoserver loadbalanced
 type: application
-version: 1.7.0
+version: 1.7.1
 appVersion: "22.0.4"

--- a/geoserver-lb/templates/geoserver-deploy.yaml
+++ b/geoserver-lb/templates/geoserver-deploy.yaml
@@ -74,7 +74,8 @@ spec:
         env:
         - name: GIT_SSH_COMMAND
           value: ssh -o "IdentitiesOnly=yes" -o "StrictHostKeyChecking no"
-        image: alpine/git
+        image: {{ .Values.geoserver.git.docker_image }}
+        imagePullPolicy: {{ .Values.geoserver.git.docker_image_pull_policy }}
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File

--- a/geoserver-lb/values.yaml
+++ b/geoserver-lb/values.yaml
@@ -27,6 +27,8 @@ geoserver:
   replicas: 1
   jetty_monitoring: false
   git:
+    docker_image: alpine/git
+    docker_image_pull_policy: IfNotPresent
     repository_url: git@github.com:org/georchestra-client-configuration.git
     branch: k8s-master
   reloader:

--- a/geoserver-lb/values.yaml
+++ b/geoserver-lb/values.yaml
@@ -27,7 +27,7 @@ geoserver:
   replicas: 1
   jetty_monitoring: false
   git:
-    docker_image: alpine/git
+    docker_image: alpine/git:2.49.1
     docker_image_pull_policy: IfNotPresent
     repository_url: git@github.com:org/georchestra-client-configuration.git
     branch: k8s-master


### PR DESCRIPTION
in a constrained environment, it might be necessary to use another docker repository for the image which pulls the geOrchestra datadir.

tests: mainly `helm template .` based tests