### PR TITLE
feat: add limits requests to airflow components

### DIFF
--- a/datafeeder-python/Chart.yaml
+++ b/datafeeder-python/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/datafeeder-python/values.yaml
+++ b/datafeeder-python/values.yaml
@@ -9,7 +9,12 @@ backend:
     repository: ghcr.io/camptocamp/datafeeder/datafeeder-python-backend
     pullPolicy: Always
     tag: latest
-  resources: {}
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   podSecurityContext:
     runAsUser: 10000
     runAsGroup: 10001
@@ -88,7 +93,12 @@ frontend:
     repository: ghcr.io/camptocamp/datafeeder/datafeeder-python-frontend
     pullPolicy: Always
     tag: latest
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      memory: 128Mi
   podSecurityContext:
     runAsUser: 101
     runAsGroup: 101
@@ -136,6 +146,12 @@ airflow:
     password: ~
     persistence:
       enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi
 
   statsd:
     enabled: false
@@ -178,8 +194,44 @@ airflow:
   triggerer:
     persistence:
       enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+
+  scheduler:
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+  apiServer:
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+
+  dagProcessor:
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
 
   workers:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        memory: 5Gi
     celery:
       persistence:
         enabled: true

--- a/datafeeder-python/values.yaml
+++ b/datafeeder-python/values.yaml
@@ -140,7 +140,7 @@ airflow:
   env:
     - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
       value: "False"
-      
+
   redis:
     # To change
     password: ~
@@ -306,5 +306,5 @@ airflow:
 volumes:
   storage_class_name: default
   airflow_logs:
-    #pv_name: datafeeder-airflow-logs
+    # pv_name: datafeeder-airflow-logs
     size: 10Gi


### PR DESCRIPTION
Add default limits and requests to all the airflow components and backend + frontend.

These limits were based on observed usage from MEL client.

Worker, the component that ingest data from a remote resource. @jeanmi151 said that nobody will try to ingest a data that exceed 1GB so 5GB is fine. Since the worker put the data into memory while downloading.